### PR TITLE
Disable SolidAPM in test

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ The sampling is done per-thread using a round-robin counter, ensuring even distr
 This is useful for high-traffic applications where you want to reduce the volume of
 APM data while still maintaining representative performance insights.
 
+### Test Environment
+
+**SolidAPM is automatically disabled in the test
+environment** to prevent test pollution and improve test performance.
+
+You can disable SolidAPM in other environments if needed:
+
+```ruby
+# config/environments/staging.rb
+SolidApm.enabled = false
+```
+
 ### Transaction Name Filtering
 
 Filter specific transactions by name using exact string matches or regular expressions:

--- a/lib/solid_apm.rb
+++ b/lib/solid_apm.rb
@@ -4,6 +4,7 @@ require 'active_median'
 require 'apexcharts'
 
 require 'solid_apm/version'
+require 'solid_apm/railtie'
 require 'solid_apm/engine'
 require 'solid_apm/sampler'
 require 'solid_apm/cleanup_service'
@@ -13,6 +14,7 @@ module SolidApm
   mattr_accessor :mcp_server_config, default: {}
   mattr_accessor :silence_active_record_logger, default: true
   mattr_accessor :transaction_sampling, default: 1
+  mattr_accessor :enabled, default: true
   mattr_accessor(
     :transaction_filters, default: [
       /^SolidApm::/,

--- a/lib/solid_apm/engine.rb
+++ b/lib/solid_apm/engine.rb
@@ -4,7 +4,9 @@ module SolidApm
   class Engine < ::Rails::Engine
     isolate_namespace SolidApm
 
-    config.app_middleware.use Middleware
+    initializer 'solid_apm.middleware', before: :build_middleware_stack do |app|
+      app.middleware.use SolidApm::Middleware if SolidApm.enabled
+    end
 
     initializer 'solid_apm.assets' do |app|
       # Add engine's assets to the load path for both Propshaft and Sprockets
@@ -49,7 +51,7 @@ module SolidApm
     end
 
     config.after_initialize do
-      SpanSubscriber::Base.subscribe!
+      SpanSubscriber::Base.subscribe! if SolidApm.enabled
     end
   end
 end

--- a/lib/solid_apm/middleware.rb
+++ b/lib/solid_apm/middleware.rb
@@ -7,10 +7,12 @@ module SolidApm
     end
 
     def call(env)
+      return @app.call(env) unless SolidApm.enabled
+
       self.class.init_transaction
       status, headers, body = @app.call(env)
 
-        env['rack.after_reply'] ||= []
+      env['rack.after_reply'] ||= []
         env['rack.after_reply'] << ->() do
           self.class.call
         rescue StandardError => e
@@ -25,8 +27,8 @@ module SolidApm
       SpanSubscriber::Base.transaction = nil
 
       if transaction.nil? ||
-          transaction_filtered?(transaction.name) ||
-          !Sampler.should_sample?
+         transaction_filtered?(transaction.name) ||
+         !Sampler.should_sample?
 
         SpanSubscriber::Base.spans = nil
         return

--- a/lib/solid_apm/railtie.rb
+++ b/lib/solid_apm/railtie.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module SolidApm
+  class Railtie < Rails::Railtie
+    config.before_initialize do
+      # Always disable in test environment to prevent test pollution
+      SolidApm.enabled = false if Rails.env.test?
+    end
+  end
+end

--- a/spec/lib/solid_apm/configuration_spec.rb
+++ b/spec/lib/solid_apm/configuration_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'SolidApm configuration' do
+  describe '.enabled' do
+    it 'is disabled in test environment' do
+      # SolidAPM is always disabled in test to prevent pollution
+      expect(SolidApm.enabled).to be false
+    end
+
+    it 'can be set to false' do
+      original = SolidApm.enabled
+      SolidApm.enabled = false
+      expect(SolidApm.enabled).to be false
+      SolidApm.enabled = original
+    end
+  end
+end

--- a/spec/lib/solid_apm/railtie_spec.rb
+++ b/spec/lib/solid_apm/railtie_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SolidApm::Railtie do
+  describe 'test environment auto-disable' do
+    it 'is disabled in test environment' do
+      # Railtie always disables in test environment
+      expect(Rails.env.test?).to be true
+      expect(SolidApm.enabled).to be false
+    end
+  end
+end

--- a/spec/services/solid_apm/middleware_spec.rb
+++ b/spec/services/solid_apm/middleware_spec.rb
@@ -1,6 +1,23 @@
 # frozen_string_literal: true
 
 RSpec.describe SolidApm::Middleware do
+  describe 'when disabled' do
+    it 'passes through without tracking' do
+      original = SolidApm.enabled
+      SolidApm.enabled = false
+
+      app = ->(_env) { [200, {}, ['OK']] }
+      middleware = described_class.new(app)
+
+      status, _headers, _body = middleware.call({})
+
+      expect(status).to eq(200)
+      expect(SolidApm::SpanSubscriber::Base.transaction).to be_nil
+
+      SolidApm.enabled = original
+    end
+  end
+
   describe '.transaction_filtered?' do
     before do
       SolidApm.transaction_filters = []

--- a/spec/services/solid_apm/middleware_spec.rb
+++ b/spec/services/solid_apm/middleware_spec.rb
@@ -2,10 +2,15 @@
 
 RSpec.describe SolidApm::Middleware do
   describe 'when disabled' do
-    it 'passes through without tracking' do
+    around do |example|
       original = SolidApm.enabled
       SolidApm.enabled = false
+      example.run
+    ensure
+      SolidApm.enabled = original
+    end
 
+    it 'passes through without tracking' do
       app = ->(_env) { [200, {}, ['OK']] }
       middleware = described_class.new(app)
 
@@ -13,8 +18,6 @@ RSpec.describe SolidApm::Middleware do
 
       expect(status).to eq(200)
       expect(SolidApm::SpanSubscriber::Base.transaction).to be_nil
-
-      SolidApm.enabled = original
     end
   end
 


### PR DESCRIPTION
This pull request introduces a configurable `enabled` flag to SolidAPM, allowing the APM functionality to be disabled, with automatic disabling in the test environment to prevent test pollution and improve test performance. The changes ensure that SolidAPM's middleware and subscribers are only active when enabled, and provide documentation and tests for this behavior.

**Configuration and Environment Handling:**

* Added a `SolidApm.enabled` configuration flag, defaulting to `true`, and automatically set to `false` in the test environment via a new `Railtie` (`lib/solid_apm.rb`, `lib/solid_apm/railtie.rb`, [[1]](diffhunk://#diff-8361d6aa97451438a36bb7f0c7227d49a06d42a0f0b87ed2804b28e6f2ae1416R17) [[2]](diffhunk://#diff-12a803662a93849c825f5147134103c98a797249a48bd5938f499820dd94f7deR1-R10).
* Updated documentation in `README.md` to explain the new `enabled` flag and its default behavior in the test environment.

**Middleware and Subscriber Activation:**

* Modified the initialization of middleware and span subscribers to respect the `enabled` flag, ensuring they are only active when SolidAPM is enabled (`lib/solid_apm/engine.rb`, [[1]](diffhunk://#diff-bbc3cc0c85ced5645fdb35fad8b9d9d9d641209870854bf2166e5954922c1717L7-R9) [[2]](diffhunk://#diff-bbc3cc0c85ced5645fdb35fad8b9d9d9d641209870854bf2166e5954922c1717L52-R54).
* Updated the middleware to bypass tracking when SolidAPM is disabled (`lib/solid_apm/middleware.rb`, [lib/solid_apm/middleware.rbR10-R11](diffhunk://#diff-83170232c2dad8af07b3f886693ec3cfcdba34a94f648060dba343a6b49a3997R10-R11)).
